### PR TITLE
support other database engines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 /composer.lock
+.idea

--- a/src/Metrics/Trend.php
+++ b/src/Metrics/Trend.php
@@ -186,7 +186,7 @@ class Trend extends Metric
         $grammar = $this->query->getQuery()->getGrammar();
         $dateColumn = $grammar->wrap($this->getDateColumn());
 
-        if (!in_array($this->unit, ['year', 'month', 'week', 'day', 'hour', 'minute'], true)) {
+        if (! in_array($this->unit, ['year', 'month', 'week', 'day', 'hour', 'minute'], true)) {
             throw new \InvalidArgumentException("Invalid unit: {$this->unit}");
         }
 
@@ -197,7 +197,7 @@ class Trend extends Metric
                     'month' => "strftime('%Y-%m', $dateColumn)",
                     'week' => "strftime('%x-%v', $dateColumn)",
                     'day' => "strftime('%Y-%m-%d', $dateColumn)",
-                    'hour' => "strftime('%Y-%m-%d %H:00', $dateColumn, )",
+                    'hour' => "strftime('%Y-%m-%d %H:00', $dateColumn)",
                     'minute' => "strftime('%Y-%m-%d %H:%i:00', $dateColumn)",
                 };
             case 'mariadb':
@@ -221,12 +221,12 @@ class Trend extends Metric
                 };
             case 'sqlsrv':
                 return match ($this->unit) {
-                    'year' => "FORMAT($dateColumn, 'YYYY')",
-                    'month' => "FORMAT($dateColumn, 'YYYY-MM')",
-                    'week' => "FORMAT($dateColumn, 'IYYY-IW')",
-                    'day' => "FORMAT($dateColumn, 'YYYY-MM-DD')",
-                    'hour' => "FORMAT($dateColumn, 'YYYY-MM-DD HH24:00')",
-                    'minute' => "FORMAT($dateColumn, 'YYYY-MM-DD HH24:mi:00')",
+                    'year' => "DATEPART(year, $dateColumn)",
+                    'month' => "DATEPART(month, $dateColumn)",
+                    'week' => "DATEPART(week, $dateColumn)",
+                    'day' => "DATEPART(day, $dateColumn)",
+                    'hour' => "DATEPART(hour, $dateColumn)",
+                    'minute' => "DATEPART(minute, $dateColumn)",
                 };
             default:
                 throw new \InvalidArgumentException('Laravel Easy Metrics is not supported for this database.');

--- a/src/Metrics/Trend.php
+++ b/src/Metrics/Trend.php
@@ -186,15 +186,51 @@ class Trend extends Metric
         $grammar = $this->query->getQuery()->getGrammar();
         $dateColumn = $grammar->wrap($this->getDateColumn());
 
-        return match ($this->unit) {
-            'year' => "date_format($dateColumn, '%Y')",
-            'month' => "date_format($dateColumn, '%Y-%m')",
-            'week' => "date_format($dateColumn, '%x-%v')",
-            'day' => "date_format($dateColumn, '%Y-%m-%d')",
-            'hour' => "date_format($dateColumn, '%Y-%m-%d %H:00')",
-            'minute' => "date_format($dateColumn, '%Y-%m-%d %H:%i:00')",
-            default => throw new \InvalidArgumentException("Invalid unit: {$this->unit}"),
-        };
+        if (!in_array($this->unit, ['year', 'month', 'week', 'day', 'hour', 'minute'], true)) {
+            throw new \InvalidArgumentException("Invalid unit: {$this->unit}");
+        }
+
+        switch ($this->query->getConnection()->getDriverName()) {
+            case 'sqlite':
+                return match ($this->unit) {
+                    'year' => "strftime('%Y', $dateColumn)",
+                    'month' => "strftime('%Y-%m', $dateColumn)",
+                    'week' => "strftime('%x-%v', $dateColumn)",
+                    'day' => "strftime('%Y-%m-%d', $dateColumn)",
+                    'hour' => "strftime('%Y-%m-%d %H:00', $dateColumn, )",
+                    'minute' => "strftime('%Y-%m-%d %H:%i:00', $dateColumn)",
+                };
+            case 'mariadb':
+            case 'mysql':
+                return match ($this->unit) {
+                    'year' => "date_format($dateColumn, '%Y')",
+                    'month' => "date_format($dateColumn, '%Y-%m')",
+                    'week' => "date_format($dateColumn, '%x-%v')",
+                    'day' => "date_format($dateColumn, '%Y-%m-%d')",
+                    'hour' => "date_format($dateColumn, '%Y-%m-%d %H:00')",
+                    'minute' => "date_format($dateColumn, '%Y-%m-%d %H:%i:00')",
+                };
+            case 'pgsql':
+                return match ($this->unit) {
+                    'year' => "to_char($dateColumn, 'YYYY')",
+                    'month' => "to_char($dateColumn, 'YYYY-MM')",
+                    'week' => "to_char($dateColumn, 'IYYY-IW')",
+                    'day' => "to_char($dateColumn, 'YYYY-MM-DD')",
+                    'hour' => "to_char($dateColumn, 'YYYY-MM-DD HH24:00')",
+                    'minute' => "to_char($dateColumn, 'YYYY-MM-DD HH24:mi:00')",
+                };
+            case 'sqlsrv':
+                return match ($this->unit) {
+                    'year' => "FORMAT($dateColumn, 'YYYY')",
+                    'month' => "FORMAT($dateColumn, 'YYYY-MM')",
+                    'week' => "FORMAT($dateColumn, 'IYYY-IW')",
+                    'day' => "FORMAT($dateColumn, 'YYYY-MM-DD')",
+                    'hour' => "FORMAT($dateColumn, 'YYYY-MM-DD HH24:00')",
+                    'minute' => "FORMAT($dateColumn, 'YYYY-MM-DD HH24:mi:00')",
+                };
+            default:
+                throw new \InvalidArgumentException('Laravel Easy Metrics is not supported for this database.');
+        }
     }
 
     protected function getFormat(): string


### PR DESCRIPTION
I am using SQLite which has no `date_format` function but `strftime`. Hence, the current implementation didn't work for me and I added support for SQLite.

I added support for other databases as well, but I haven't tested them. I am not sure what you think about untested code (I haven't tested pgsql, sqlsrv functions)... 